### PR TITLE
Converted to annotations, documented most everything.

### DIFF
--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -29,20 +29,7 @@
     </repository>
   </repositories>
 
-  <build>
-    <plugins>
-      <plugin>
-        <artifactId>maven-plugin-plugin</artifactId>
-        <version>2.3</version>
-        <configuration>
-          <goalPrefix>robovm</goalPrefix>
-        </configuration>
-      </plugin>
-    </plugins>
-  </build>
-
   <dependencies>
-
     <dependency>
       <groupId>org.robovm</groupId>
       <artifactId>robovm-dist-compiler</artifactId>
@@ -67,6 +54,12 @@
     </dependency>
 
     <dependency>
+      <groupId>org.apache.maven.plugin-tools</groupId>
+      <artifactId>maven-plugin-annotations</artifactId>
+      <version>3.1</version>
+    </dependency>
+
+    <dependency>
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-compat</artifactId>
       <version>3.0</version>
@@ -74,4 +67,62 @@
     </dependency>
   </dependencies>
 
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-plugin-plugin</artifactId>
+        <version>3.2</version>
+        <configuration>
+          <skipErrorNoDescriptorsFound>true</skipErrorNoDescriptorsFound>
+          <goalPrefix>robovm</goalPrefix>
+          <extractors>
+            <extractor>java-annotations</extractor>
+          </extractors>
+        </configuration>
+        <executions>
+          <execution>
+            <id>mojo-descriptor</id>
+            <goals>
+              <goal>descriptor</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+
+  <reporting>
+    <excludeDefaults>true</excludeDefaults>
+    <outputDirectory>${project.build.directory}/site</outputDirectory>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-plugin-plugin</artifactId>
+        <version>3.2</version>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-project-info-reports-plugin</artifactId>
+        <version>2.7</version>
+        <configuration>
+          <dependencyDetailsEnabled>false</dependencyDetailsEnabled>
+          <dependencyLocationsEnabled>false</dependencyLocationsEnabled>
+        </configuration>
+        <reportSets>
+          <reportSet>
+            <reports>
+              <report>index</report>
+              <report>summary</report>
+            </reports>
+          </reportSet>
+        </reportSets>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-javadoc-plugin</artifactId>
+        <version>2.8</version>
+      </plugin>
+    </plugins>
+  </reporting>
 </project>

--- a/plugin/src/main/java/org/robovm/maven/plugin/AbstractIOSSimulatorMojo.java
+++ b/plugin/src/main/java/org/robovm/maven/plugin/AbstractIOSSimulatorMojo.java
@@ -17,6 +17,7 @@ package org.robovm.maven.plugin;
 
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.plugins.annotations.Parameter;
 import org.robovm.compiler.config.Arch;
 import org.robovm.compiler.config.Config;
 import org.robovm.compiler.config.Config.TargetType;
@@ -33,13 +34,17 @@ public abstract class AbstractIOSSimulatorMojo extends AbstractRoboVMMojo {
     private DeviceFamily deviceFamily;
 
     /**
-     * @parameter expression="${robovm.iosSimSdk}"
+     * The iOS SDK version to use when choosing the simulator (e.g. "8.0"). Defaults to the newest
+     * SDK version.
      */
+    @Parameter(property="robovm.iosSimSdk")
     protected String sdk;
 
     /**
-     * @parameter expression="${robovm.iosDeviceName}"
+     * The identifier of the simulator device to use (e.g. "iPhone-5s", "iPad-Retina"). Run {@code
+     * ios-sim showdevicetypes} for a full list.
      */
+    @Parameter(property="robovm.iosDeviceName")
     protected String deviceName;
 
     protected AbstractIOSSimulatorMojo(DeviceFamily deviceFamily) {

--- a/plugin/src/main/java/org/robovm/maven/plugin/AbstractRoboVMMojo.java
+++ b/plugin/src/main/java/org/robovm/maven/plugin/AbstractRoboVMMojo.java
@@ -34,6 +34,8 @@ import org.apache.maven.model.Plugin;
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.plugins.annotations.Component;
+import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.project.MavenProject;
 import org.codehaus.plexus.archiver.UnArchiver;
 import org.codehaus.plexus.archiver.manager.ArchiverManager;
@@ -45,9 +47,9 @@ import org.codehaus.plexus.util.xml.Xpp3DomWriter;
 import org.robovm.compiler.AppCompiler;
 import org.robovm.compiler.Version;
 import org.robovm.compiler.config.Arch;
-import org.robovm.compiler.config.Config;
 import org.robovm.compiler.config.Config.Lib;
 import org.robovm.compiler.config.Config.TargetType;
+import org.robovm.compiler.config.Config;
 import org.robovm.compiler.config.OS;
 import org.robovm.compiler.log.Logger;
 import org.robovm.compiler.target.ios.ProvisioningProfile;
@@ -57,35 +59,16 @@ import org.robovm.compiler.target.ios.SigningIdentity;
  */
 public abstract class AbstractRoboVMMojo extends AbstractMojo {
 
-    /**
-     * The maven project.
-     * 
-     * @parameter expression="${project}"
-     * @required
-     */
+    @Component
     protected MavenProject project;
 
-    /**
-     * To look up Archiver/UnArchiver implementations
-     * 
-     * @component
-     * @readonly
-     */
+    @Component
     private ArchiverManager archiverManager;
 
-    /**
-     * To resolve artifacts
-     * 
-     * @component
-     * @readonly
-     */
+    @Component
     private ArtifactResolver artifactResolver;
 
-    /**
-     * 
-     * @parameter default-value="${localRepository}"
-     * 
-     */
+    @Parameter(defaultValue="${localRepository}")
     private ArtifactRepository localRepository;
 
     /**
@@ -93,57 +76,54 @@ public abstract class AbstractRoboVMMojo extends AbstractMojo {
      * robovm-dist bundle will be downloaded from Maven and extracted into this
      * directory. Note that each release of RoboVM is placed in a separate
      * sub-directory with the version number as suffix.
-     * 
+     *
      * If not set, then the tar file is extracted into the local Maven
      * repository where the tar file is downloaded to.
-     * 
-     * @parameter
      */
+    @Parameter
     protected File home;
 
     /**
-     * @parameter expression="${robovm.propertiesFile}"
+     * The path to a {@code robovm.properties} file which contains info for your app.
      */
+    @Parameter(property="robovm.propertiesFile")
     protected File propertiesFile;
 
     /**
-     * @parameter expression="${robovm.configFile}"
+     * The path to a {@code robovm.xml} file which configures the RoboVM compiler.
      */
+    @Parameter(property="robovm.configFile")
     protected File configFile;
 
     /**
      * The identity to sign the app as when building an iOS bundle for the app.
-     * 
-     * @parameter expression="${robovm.iosSignIdentity}"
      */
+    @Parameter(property="robovm.iosSignIdentity")
     protected String iosSignIdentity;
 
     /**
-     * The provisioning profile to use when building for device..
-     * 
-     * @parameter expression="${robovm.iosProvisioningProfile}"
+     * The provisioning profile to use when building for device.
      */
+    @Parameter(property="robovm.iosProvisioningProfile")
     protected String iosProvisioningProfile;
 
     /**
-     * Whether the app should be signed or not. Unsigned apps can only be run
-     * on jailbroken devices.
-     *
-     * @parameter expression="${robovm.iosSkipSigning}"
+     * Whether the app should be signed or not. Unsigned apps can only be run on jailbroken
+     * devices.
      */
+    @Parameter(property="robovm.iosSkipSigning")
     protected boolean iosSkipSigning = false;
 
     /**
-     * The directory that the RoboVM distributable for the project will be built
-     * to.
-     * 
-     * @parameter expression="${project.build.directory}/robovm"
+     * The directory into which the RoboVM distributable for the project will be built.
      */
+    @Parameter(property="robovm.installDir", defaultValue="${project.build.directory}/robovm")
     protected File installDir;
 
     /**
-     * @parameter
+     * Whether or not to include the JavaFX libraries.
      */
+    @Parameter(property="robovm.includeJFX")
     protected boolean includeJFX;
 
     private Logger roboVMLogger;
@@ -188,7 +168,7 @@ public abstract class AbstractRoboVMMojo extends AbstractMojo {
                 builder.readProjectProperties(project.getBasedir(), false);
             } catch (IOException e) {
                 throw new MojoExecutionException(
-                        "Failed to read RoboVM project properties file(s) in " 
+                        "Failed to read RoboVM project properties file(s) in "
                                 + project.getBasedir().getAbsolutePath(), e);
             }
         }
@@ -213,7 +193,7 @@ public abstract class AbstractRoboVMMojo extends AbstractMojo {
                 builder.readProjectConfig(project.getBasedir(), false);
             } catch (Exception e) {
                 throw new MojoExecutionException(
-                        "Failed to read project RoboVM config file in " 
+                        "Failed to read project RoboVM config file in "
                                 + project.getBasedir().getAbsolutePath(), e);
             }
         }

--- a/plugin/src/main/java/org/robovm/maven/plugin/CreateIPAMojo.java
+++ b/plugin/src/main/java/org/robovm/maven/plugin/CreateIPAMojo.java
@@ -17,21 +17,23 @@ package org.robovm.maven.plugin;
 
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.plugins.annotations.LifecyclePhase;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.ResolutionScope;
 import org.robovm.compiler.config.Arch;
-import org.robovm.compiler.config.Config;
 import org.robovm.compiler.config.Config.Builder;
 import org.robovm.compiler.config.Config.TargetType;
+import org.robovm.compiler.config.Config;
 import org.robovm.compiler.config.OS;
 import org.robovm.compiler.target.ios.IOSTarget;
 
 import java.io.IOException;
 
 /**
- * @goal create-ipa
- * @phase package
- * @execute phase="package"
- * @requiresDependencyResolution
+ * Compiles your application and creates an IPA file suitable for upload to the app store.
  */
+@Mojo(name="create-ipa", defaultPhase=LifecyclePhase.PACKAGE,
+      requiresDependencyResolution=ResolutionScope.COMPILE_PLUS_RUNTIME)
 public class CreateIPAMojo extends AbstractRoboVMMojo {
 
     @Override

--- a/plugin/src/main/java/org/robovm/maven/plugin/IOSDeviceMojo.java
+++ b/plugin/src/main/java/org/robovm/maven/plugin/IOSDeviceMojo.java
@@ -17,20 +17,22 @@ package org.robovm.maven.plugin;
 
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.plugins.annotations.LifecyclePhase;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.ResolutionScope;
 import org.robovm.compiler.config.Arch;
-import org.robovm.compiler.config.Config;
 import org.robovm.compiler.config.Config.TargetType;
+import org.robovm.compiler.config.Config;
 import org.robovm.compiler.config.OS;
 import org.robovm.compiler.target.LaunchParameters;
 
 import java.io.IOException;
 
 /**
- * @goal ios-device
- * @phase package
- * @execute phase="package"
- * @requiresDependencyResolution
+ * Compiles your application and deploys it to a connected iOS device.
  */
+@Mojo(name="ios-device", defaultPhase=LifecyclePhase.PACKAGE,
+      requiresDependencyResolution=ResolutionScope.COMPILE_PLUS_RUNTIME)
 public class IOSDeviceMojo extends AbstractRoboVMMojo {
 
     @Override

--- a/plugin/src/main/java/org/robovm/maven/plugin/IPadSimMojo.java
+++ b/plugin/src/main/java/org/robovm/maven/plugin/IPadSimMojo.java
@@ -15,14 +15,16 @@
  */
 package org.robovm.maven.plugin;
 
+import org.apache.maven.plugins.annotations.LifecyclePhase;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.ResolutionScope;
 import org.robovm.compiler.target.ios.DeviceType.DeviceFamily;
 
 /**
- * @goal ipad-sim
- * @phase package
- * @execute phase="package"
- * @requiresDependencyResolution
+ * Compiles your application and deploys it to the iPad simulator.
  */
+@Mojo(name="ipad-sim", defaultPhase=LifecyclePhase.PACKAGE,
+      requiresDependencyResolution=ResolutionScope.COMPILE_PLUS_RUNTIME)
 public class IPadSimMojo extends AbstractIOSSimulatorMojo {
 
     public IPadSimMojo() {

--- a/plugin/src/main/java/org/robovm/maven/plugin/IPhoneSimMojo.java
+++ b/plugin/src/main/java/org/robovm/maven/plugin/IPhoneSimMojo.java
@@ -15,14 +15,16 @@
  */
 package org.robovm.maven.plugin;
 
+import org.apache.maven.plugins.annotations.LifecyclePhase;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.ResolutionScope;
 import org.robovm.compiler.target.ios.DeviceType.DeviceFamily;
 
 /**
- * @goal iphone-sim
- * @phase package
- * @execute phase="package"
- * @requiresDependencyResolution
+ * Compiles your application and deploys it to the iPhone simulator.
  */
+@Mojo(name="iphone-sim", defaultPhase=LifecyclePhase.PACKAGE,
+      requiresDependencyResolution=ResolutionScope.COMPILE_PLUS_RUNTIME)
 public class IPhoneSimMojo extends AbstractIOSSimulatorMojo {
 
     public IPhoneSimMojo() {

--- a/plugin/src/site/apt/index.apt.vm
+++ b/plugin/src/site/apt/index.apt.vm
@@ -1,0 +1,87 @@
+ ------
+ Introduction
+ ------
+ Michael Bayne
+ ------
+ 2014-11-11
+ ------
+
+ ~~ Copyright (C) 2013 Trillian Mobile AB.
+ ~~
+ ~~ Licensed under the Apache License, Version 2.0 (the "License");
+ ~~ you may not use this file except in compliance with the License.
+ ~~ You may obtain a copy of the License at
+ ~~
+ ~~      http://www.apache.org/licenses/LICENSE-2.0
+ ~~
+ ~~ Unless required by applicable law or agreed to in writing, software
+ ~~ distributed under the License is distributed on an "AS IS" BASIS,
+ ~~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ ~~ See the License for the specific language governing permissions and
+ ~~ limitations under the License.
+
+ ~~ NOTE: For help with the syntax of this file, see:
+ ~~ http://maven.apache.org/doxia/references/apt-format.html
+
+${project.name}
+
+  This plugin provides the ability to build and deploy RoboVM apps to the iOS simulator and devices,
+  as well as to generate IPA files.
+
+* Goals Overview
+
+  * {{{./ipad-sim-mojo.html}robovm:ipad-sim}} compile and deploy your app to the iPad simulator.
+
+  * {{{./iphone-sim-mojo.html}robovm:iphone-sim}} compile and deploy your app to the iPhone simulator.
+
+  * {{{./ios-device-mojo.html}robovm:ios-device}} compile and deploy your app to an iOS device.
+
+  * {{{./create-ipa-mojo.html}robovm:create-ipa}} compile and bundle your app into an IPA file.
+
+  []
+
+* Usage
+
+  Integrating the plugin mainly consists of adding it to your <<<pom.xml>>> file along with
+  dependencies on the main RoboVM jars:
+
++-----------------+
+<project>
+  ...
+  <dependencies>
+    ...
+    <dependency>
+      <groupId>org.robovm</groupId>
+      <artifactId>robovm-rt</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.robovm</groupId>
+      <artifactId>robovm-cocoatouch</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+  </dependencies>
+  ...
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.robovm</groupId>
+        <artifactId>robovm-maven-plugin</artifactId>
+        <version>${project.version}</version>
+      </plugin>
+      ...
+    </plugins>
+  </build>
+</project>
++-----------------+
+
+  Then invoke one of the above targets from the command line. For example:
+  <<<mvn robovm:ipad-sim>>>
+
+  See the many {{{https://github.com/robovm/robovm-samples}RoboVM samples}} for examples of the
+  RoboVM Maven plugin in working projects.
+
+  In case you still have questions regarding the plugin's usage, feel free to contact the
+  {{{https://groups.google.com/forum/#!forum/robovm}user mailing list}}. The posts to the mailing
+  list are archived and could already contain the answer to your question as part of an older
+  thread. Hence, it is also worth browsing/searching the mail archive.

--- a/plugin/src/site/site.xml
+++ b/plugin/src/site/site.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<project xmlns="http://maven.apache.org/DECORATION/1.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/DECORATION/1.0.0 http://maven.apache.org/xsd/decoration-1.0.0.xsd">
+  <body>
+    <menu name="Overview">
+      <item name="Introduction" href="index.html"/>
+      <item name="Goals" href="plugin-info.html"/>
+<!--
+      <item name="Usage" href="usage.html"/>
+      <item name="FAQ" href="faq.html"/>
+    -->
+    </menu>
+  </body>
+</project>

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,6 @@
   <name>RoboVM Maven</name>
   <packaging>pom</packaging>
 
-    
   <url>https://github.com/robovm/robovm-maven-plugin</url>
   <description>
     Maven support for RoboVM
@@ -31,6 +30,13 @@
     <name>Trillian Mobile AB</name>
     <url>http://www.robovm.com</url>
   </organization>
+
+  <mailingLists>
+    <mailingList>
+      <name>RoboVM Discussion</name>
+      <archive>https://groups.google.com/forum/#!forum/robovm</archive>
+    </mailingList>
+  </mailingLists>
 
   <licenses>
     <license>


### PR DESCRIPTION
This also includes a bunch of POM shenanigans to allow the standard "Maven
plugin website" to be generated, which provides documentation for all of the
plugin configuration and which is extremely useful to someone trying to figure
out how to use the plugin.

I've published an example of that website here: http://samskivert.com/robovm-maven-plugin/

You can generate it locally like so:

```
cd plugin
mvn site
open target/site/index.html
```

Ideally this generated site can be published at robovm.github.io/robovm-maven-plugin/. The way that works is that one creates a `gh-pages` branch and everything committed to that branch goes up on this magic website. Once the branch is created, I think I can generate the site and submit a pull request which will ship it. Then I can send another pull request once everything goes to 1.0.

Incidentally, the reason I'm working hard to get the Maven plugin in shape is because the Maven plugin version is tied to the RoboVM version. That's not awesome, but based on the way the code is, it would be hard to change. So I want to be sure that the Maven plugin doesn't suck for the 1.0 release, because I'm going to be foisting it on all the PlayN users who want to use the (forthcoming) new RoboVM backend. :)
